### PR TITLE
Get Google CDN library name attribute from its path

### DIFF
--- a/lib/scrape_google.js
+++ b/lib/scrape_google.js
@@ -14,9 +14,10 @@ module.exports = function(data) {
         var $e = $(e);
         var dd = $e.find('dd');
         var mainfile = $e.find('code').text().split('"').slice(-2, -1)[0].split('/').slice(-1)[0];
-        var name = $e.find('dt').text();
+        var name = $e.find('code').text().split('"').slice(-2, -1)[0].split('/')[5];
         var versions = getVersions($(dd[2])).concat(getVersions($(dd[3]))).sort();
         var hasMin = $e.find('code').text().indexOf('.min.js') !== -1;
+        var description = $e.find('dt').text();
 
         ret.push({
             name: name,
@@ -24,7 +25,8 @@ module.exports = function(data) {
             homepage: $(dd[1]).find('a').attr('href'),
             lastversion: versions.slice(-1)[0],
             assets: getAssets(mainfile, versions, hasMin),
-            versions: versions
+            versions: versions,
+            description: description
         });
     });
 


### PR DESCRIPTION
All of the other CDNs supported by the API seem to do it this way, and it certainly makes it easier to build a URL from a result.

`/v1/google/libraries?fields=name,description&limit=3` before:

```
[
  {
    "name": "AngularJS"
  }, {
    "name": "Dojo"
  }, {
    "name": "Ext Core"
  }
]
```

The same request, after:

```
[
  {
    "name": "angularjs",
    "description": "AngularJS"
  }, {
    "name": "dojo",
    "description": "Dojo"
  }, {
    "name": "ext-core",
    "description": "Ext Core"
  }
]
```
