### PR TITLE
Sort results by Levenshtein distance from the requested name

### DIFF
--- a/lib/get_all.js
+++ b/lib/get_all.js
@@ -2,7 +2,7 @@ var minimatch = require('minimatch');
 var is = require('annois');
 var fp = require('annofp');
 var zip = require('annozip');
-
+var levenshtein = require('fast-levenshtein');
 
 module.exports = function(model, query, cb) {
     if(!is.object(query) || fp.count(query) === 0) {
@@ -63,6 +63,18 @@ module.exports = function(model, query, cb) {
             });
 
             return r;
+        });
+    }
+
+    // sort results by Levenshtein distance from the requested name
+    var name_i = zq.map(function(q) { return q[0]; }).indexOf('name');
+    if (name_i !== -1 && is.string(zq[name_i][1])) {
+        var name = zq[name_i][1].toLowerCase();
+
+        ret = ret.sort(function(a, b) {
+            a = a.name.toLowerCase();
+            b = b.name.toLowerCase();
+            return levenshtein.get(a, name) - levenshtein.get(b, name);
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "annois": "~0.3.0",
     "annozip": "0.2.1",
     "minimatch": "~0.2.14",
-    "github": "~0.1.14"
+    "github": "~0.1.14",
+    "fast-levenshtein": "~1.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I noticed that searching for `name=jquery*` on CDNJS did not return jQuery as the top result, or even in the top 100 results!
http://api.jsdelivr.com/v1/cdnjs/libraries?name=jquery*&limit=100&fields=name

This sorts the results (before a limit is imposed) based on the [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) between the package name and the requested name (it would probably muss up a bit if one was to go nuts with the minimatch syntax).

Before (`name=jquery*&limit=4&fields=name`):

```
[
  {
    "name": "jQuery-Geolocation"
  },
  {
    "name": "jQuery-Validation-Engine"
  },
  {
    "name": "jQuery-slimScroll"
  },
  {
    "name": "jQuery.dotdotdot"
  }
]
```

After:

```
[
  {
    "name": "jquery"
  },
  {
    "name": "jqueryui"
  },
  {
    "name": "jquery-te"
  },
  {
    "name": "jquery.pep"
  }
]
```
