### PR TITLE
Correct sync task interval and buffer up error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.swp
+.idea

--- a/config/config.template.js
+++ b/config/config.template.js
@@ -4,7 +4,7 @@ module.exports = {
     cdns: ['bootstrap', 'cdnjs', 'google', 'jsdelivr'],
     syncUrl: 'http://jsdelivrapi-sync.aws.af.cm/data/',
     tasks: {
-        sync: {minute: 0}
+        sync: {minute: 2}
     },
     maxcdn: {
         alias: 'replace this',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "1.3.x"
   },
   "scripts": {
-    "start": "serve.js",
+    "start": "node serve.js",
     "test": "node tests"
   },
   "author": "Juho Vepsalainen",
@@ -26,7 +26,7 @@
     "object-sugar": "0.7.6",
     "maxcdn": "0.1.5",
     "parse-env": "0.2.2",
-    "request": "2.33.0",
+    "request": "2.53.0",
     "require-dir": "0.1.0",
     "rest-sugar": "0.6.3",
     "taskist": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -21,16 +21,17 @@
     "annozip": "0.2.1",
     "async": "^0.8.0",
     "express": "3.4.8",
+    "fast-levenshtein": "~1.0.0",
+    "lodash": "^3.5.0",
     "log-timestamp": "^0.1.1",
-    "minimatch": "~0.2.14",
-    "object-sugar": "0.7.6",
     "maxcdn": "0.1.5",
+    "minimatch": "~0.2.14",
+    "node-schedule": "^0.2.6",
+    "object-sugar": "0.7.6",
     "parse-env": "0.2.2",
     "request": "2.53.0",
     "require-dir": "0.1.0",
-    "rest-sugar": "0.6.3",
-    "taskist": "0.3.1",
-    "fast-levenshtein": "~1.0.0"
+    "rest-sugar": "0.6.3"
   },
   "repository": {
     "type": "git",

--- a/tasks/sync.js
+++ b/tasks/sync.js
@@ -19,8 +19,11 @@ module.exports = function(imports) {
                 json: true
             }, function(err, res, libraries) {
 
-                if(err || res.statusCode !== 200) {
+                if(err || !res) {
                     return cb(err || new Error("Request to sync " + cdn + " from " + _url + " failed"));
+                }
+                else if(res.statusCode !== 200) {
+                  return cb(new Error("Request to sync " + cdn + " from " + _url + " failed"));
                 }
 
                 var schema = imports.schemas[cdn + 'Library'];

--- a/tasks/sync.js
+++ b/tasks/sync.js
@@ -12,13 +12,15 @@ module.exports = function(imports) {
 
     return function(cb) {
         async.each(imports.cdns, function(cdn, cb) {
-            console.log('Starting to sync', cdn);
+            var _url = url.resolve(imports.url, cdn + '.json');
+            console.log('Starting to sync %s from source %s', cdn,_url);
 
-            request.get(url.resolve(imports.url, cdn + '.json'), {
+            request.get(_url, {
                 json: true
             }, function(err, res, libraries) {
-                if(err) {
-                    return cb(err);
+
+                if(err || res.statusCode !== 200) {
+                    return cb(err || new Error("Request to sync " + cdn + " from " + _url + " failed"));
                 }
 
                 var schema = imports.schemas[cdn + 'Library'];


### PR DESCRIPTION
- Remove `taskist` module and switch to straight `node-schedule` module to resolve non-frequent sync updates w/ `jsdelivr/api-sync`
- Properly return error in `tasks/sync.js` when `request` returns non-`200` response header.