### PR TITLE
Return empty array when no libraries are matched

### DIFF
--- a/lib/api.v1.js
+++ b/lib/api.v1.js
@@ -104,9 +104,8 @@ function _findOne(collection, query, actionParams, cb) {
     }) || {});
 
   if (model === null) {
-    var error = new Error("Requested library not found.");
-    error.code = 404;
-    return cb(error);
+    // Resolve with an empty array
+    return cb(null, []);
   }
 
   // the api v1 specs only attempt to get project files for a version


### PR DESCRIPTION
Fixes a bunch of bot issues see

https://github.com/jsdelivr/jsdelivr/pull/4809/

Because http://api.jsdelivr.com/v1/jsdelivr/libraries/ng-file-upload is an error instead of empty array (like it used to be)