### PR TITLE
Transpile code using babel (es6 support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,18 +5,19 @@
   "description": "jsDelivr API",
   "private": true,
   "engines": {
-    "node": "0.10.x",
-    "npm": "1.3.x"
+    "node": ">= 0.10",
+    "npm": "^2.2.0"
   },
   "scripts": {
     "start": "node serve.js",
-    "test": "node tests/test_run_server.js"
+    "test": "babel-node tests/test_run_server.js"
   },
   "author": "Juho Vepsalainen",
   "license": "MIT",
   "dependencies": {
     "annoinject": "^0.2.0",
     "async": "^0.9.0",
+    "babel": "^5.4.7",
     "express": "^4.12.3",
     "lodash": "^3.5.0",
     "log-timestamp": "^0.1.1",

--- a/serve.js
+++ b/serve.js
@@ -2,6 +2,7 @@
 'use strict';
 
 require('log-timestamp');
+require('babel/register');
 
 var express = require('express')
   , morgan = require('morgan')


### PR DESCRIPTION
I was cursing under my breath not being able to use some ES6 syntax features (template strings and destructuring mainly) in #82. This is the simplest way to add them.