### PR TITLE
Drop assests from /libraries

### DIFF
--- a/lib/api.v2.js
+++ b/lib/api.v2.js
@@ -154,26 +154,27 @@ function _selectFields(fields, models) {
 // structure the response according to v2 schema and pass through to _selectFields
 function _formatResponse(query, models) {
 
-  var _formatAssets = function formatAssets(model) {
-    return _.map(model.assets, function (asset) {
+  function _formatModel(model, excludeAssets) {
+    model.assets = excludeAssets ? void 0 : _.map(model.assets, asset => {
       var obj = {};
       obj[asset.version] = asset;
       delete asset.version;
       return obj;
     });
-  };
+    model.$loki = void 0;
+  }
 
   var response = _.clone(models);
   if (_.isArray(models)) {
     response = _.map(response, function (model) {
       if (model.assets) {
-        model.assets = _formatAssets(model);
+        _formatModel(model, true);
       }
       return model;
     });
   }
   else {
-    response.assets = _formatAssets(models);
+    _formatModel(models, false);
   }
 
   return _selectFields(query.fields || [], response);

--- a/tests/spec/v2-tests.js
+++ b/tests/spec/v2-tests.js
@@ -26,7 +26,7 @@ describe('/v2/jsdelivr/', function() {
         expect(body[0]).to.have.property('github');
         expect(body[0]).to.have.property('author');
         expect(body[0]).to.have.property('versions');
-        expect(body[0]).to.have.property('assets');
+        expect(body[0]).to.not.have.property('assets');
 
         expect(req.body).to.have.length.above(800);
 


### PR DESCRIPTION
As we've discussed, `assets` is the bulk of the response from `/libraries` while its trivial for a user to get the assets for the library they care about.

Also drops `$loki`, making for much cleaner responses!

fixes #88; fixes #74