### PR TITLE
Add support for conditional requests - closes #72

### DIFF
--- a/lib/api.v2.js
+++ b/lib/api.v2.js
@@ -11,6 +11,8 @@ import include from 'underscore.string/include';
 import APIError from './APIError';
 import buildActionParams from './buildActionParams';
 import scoreNameMatch from './scoreNameMatch';
+import dbs from '../db';
+import config from '../config';
 
 module.exports.actions = {
   'find': 'find'
@@ -110,6 +112,14 @@ function _findOne(collection, query, exactMatch, cb) {
   // See #86
   else if (nameCriteria === null && !exactMatch) {
     model = _.first(libs);
+  }
+
+  // move etag resource header into place
+  if (exactMatch) {
+    var etagsCollection = dbs[config.etagsCollection]
+      , cdnCache = etagsCollection.findOne({'cdn': collection.name}) || {etags: []}
+      , etagObj = _.find(cdnCache.etags, {path: model.name});
+    model._headers = etagObj ? {ETag: etagObj.etag} : {};
   }
 
   if (model === void 0) {

--- a/routes.v2/libraries.js
+++ b/routes.v2/libraries.js
@@ -22,7 +22,34 @@ function _sendResult(err, result, req, res) {
     res.status(error.status).json(error);
   }
   else {
+    // attach any header values contained in the result
+    if (result._headers) {
+      res.set(result._headers);
+      delete  result._headers;
+    }
+
     res.status(200).json(result);
+  }
+}
+
+function _eTagCheck(req, res, next) {
+
+  var etagHeader = 'if-none-match';
+  if (req.headers[etagHeader]) {
+
+    var etagsCollection = dbs[config.etagsCollection]
+      , cdnCache = etagsCollection.findOne({'cdn': req.collection.name}) || {etags: []}
+      , etagObj = _.find(cdnCache.etags, {etag: req.headers[etagHeader]});
+
+    if (etagObj) {
+      res.status(304).end();
+    }
+    else {
+      next();
+    }
+  }
+  else {
+    next();
   }
 }
 
@@ -51,14 +78,14 @@ router.get('/:cdn/libraries', function (req, res) {
   });
 });
 
-router.get('/:cdn/library', function (req, res) {
+router.get('/:cdn/library', [_eTagCheck], function (req, res) {
 
   api_v2.processRequest(req.collection, req.query, api_v2.actions.findOne, false, function (err, result) {
     _sendResult(err, result, req, res);
   });
 });
 
-router.get('/:cdn/library/:name', function (req, res) {
+router.get('/:cdn/library/:name', [_eTagCheck], function (req, res) {
 
   req.query.name = req.params.name;
 
@@ -67,7 +94,7 @@ router.get('/:cdn/library/:name', function (req, res) {
   });
 });
 
-router.get('/:cdn/library/:name/:version', function (req, res) {
+router.get('/:cdn/library/:name/:version', [_eTagCheck], function (req, res) {
 
   req.query.name = req.params.name;
   req.query.version = req.params.version;


### PR DESCRIPTION
@jimaek @megawac, the `ETag: "(etag val propagated from github)"` header is now passed back on resource queries that are clearly stable enough to utilize an etag cache (namely, `library` endpoints where the library in question is an `exactMatch`) and we can now receive a `304` if requesting one such resource w/ the `If-None-Match: "eTag"` header.

Can you think of any other resource routes that should also include an `ETag` header?